### PR TITLE
fixes pep8, imports missing modules and resolves logic error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,6 @@ oslo.log>=1.2.0  # Apache-2.0
 oslo.i18n>=1.5.0  # Apache-2.0
 oslo.rootwrap>=2.0.0 # Apache-2.0
 oslo.utils>=1.6.0  # Apache-2.0
-os_vif<=1.0  # Apache-2.0
 six>=1.9.0
+
+-e git+https://github.com/jaypipes/os_vif.git@master#egg=os_vif # Apache-2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,3 +52,7 @@ input_file = vif_plug_vhostuser/locale/vif-plug-vhostuser.pot
 keywords = _ gettext ngettext l_ lazy_gettext
 mapping_file = babel.cfg
 output_file = vif_plug_vhostuser/locale/vif-plug-vhostuser.pot
+
+[entry_points]
+os_vif =
+    vhostuser = vif_plug_vhostuser.vhostuser:VhostuserPlugin

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,4 @@ except ImportError:
 
 setuptools.setup(
     setup_requires=['pbr'],
-    entry_points={
-        'os_vif': [
-            'vhostuser = vif_plug_vhostuser.vhostuser:VhostuserPlugin',
-        ],
     pbr=True)

--- a/vif_plug_vhostuser/processutils.py
+++ b/vif_plug_vhostuser/processutils.py
@@ -15,13 +15,17 @@ Utility wrapper around oslo_rootwrap and oslo_concurrency.processutils
 that doesn't use oslo_cfg. Code adapted from nova.utils module.
 """
 
+import logging as std_logging
+import random
 import time
+
+import oslo_rootwrap
 
 from oslo_concurrency import processutils
 from oslo_log import log as logging
 from oslo_utils import strutils
 
-from vif_plug_vhostuser.i18n import _
+from vif_plug_vhostuser.i18n import _, _LI
 
 LOG = logging.getLogger(__name__)
 _ROOTWRAPPER = None
@@ -98,8 +102,8 @@ class RootwrapDaemonHelper(object):
                 # if we want to always log the errors or if this is
                 # the final attempt that failed and we want to log that.
                 if log_errors == processutils.LOG_ALL_ERRORS or (
-                                log_errors == processutils.LOG_FINAL_ERROR and
-                            not attempts):
+                        log_errors == processutils.LOG_FINAL_ERROR and
+                        not attempts):
                     format = _('%(desc)r\ncommand: %(cmd)r\n'
                                'exit code: %(code)r\nstdout: %(stdout)r\n'
                                'stderr: %(stderr)r')

--- a/vif_plug_vhostuser/vhostuser.py
+++ b/vif_plug_vhostuser/vhostuser.py
@@ -10,41 +10,42 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from os_vif import plugin
-from os_vif import objects
+import os
 
-from vif_plug_vhostuser import processutils
+from os_vif import objects
+from os_vif import plugin
+
 from vif_plug_vhostuser import linux_net
+from vif_plug_vhostuser import processutils
 
 PLUGIN_NAME = 'vhostuser'
 
 
 class VhostuserPlugin(plugin.PluginBase):
-    """
-    An VIF type that plugs into an OVS port using the vhostuser device
+    """An VIF type that plugs into an OVS port using the vhostuser device
     interface.
     """
 
     def __init__(self, **config):
         processutils.configure(**config)
         linux_net.configure(**config)
-        self.network_device_mtu = config.get('network_device_mtu', 1500)
         self.ovs_vsctl_timeout = config.get('ovs_vsctl_timeout', 30)
 
     def get_supported_vifs(self):
         return set([objects.PluginVIFSupport(PLUGIN_NAME, '1.0', '1.0')])
 
     def plug(self, instance, vif):
-        if vif.ovs_hybrid_plug:
+        if vif.vhostuser_ovs_plug:
             iface_id = vif.ovs_interfaceid
             port_name = os.path.basename(vif.vhostuser_socket)
-            mtu = self.network_device_mtu
-            linux_net.create_ovs_vif_port(vif.bridge_name
-                                          port_name, iface_id, vifaddress,
-                                          instance.uuid, mtu)
-            linux_net.ovs_set_vhostuser_port_type(port_name)
+            linux_net.create_ovs_vif_port(vif.bridge_name,
+                                          port_name, iface_id,
+                                          vif.address, instance.uuid,
+                                          timeout=self.ovs_vsctl_timeout,
+                                          type="dpdkvhostuser")
 
     def unplug(self, vif):
         if vif.ovs_hybrid_plug:
             port_name = os.path.basename(vif.vhostuser_socket)
-            linux_net.delete_ovs_vif_port(vif.bridge_name, port_name)
+            linux_net.delete_ovs_vif_port(vif.bridge_name, port_name,
+                                          timeout=self.ovs_vsctl_timeout)


### PR DESCRIPTION
-this change fixes pep8 so that the tox test pass.
-this change fixes module imports to enable pep8 to pass.
-this change fixes the VhostuserPlugin to invoke
 create_ovs_vif_port when vhostuser_ovs_plug instead of
 ovs_hybrid_plug
-this chage moves exporting the entry point to the setup.cfg
 to enable tox to run.
-this change update the requirement.txt to include the os_vif
 libary via a git include as it is not available in pip.
