### PR TITLE
fixes unplug method of VhostuserPlugin

### DIFF
--- a/vif_plug_vhostuser/vhostuser.py
+++ b/vif_plug_vhostuser/vhostuser.py
@@ -45,7 +45,7 @@ class VhostuserPlugin(plugin.PluginBase):
                                           type="dpdkvhostuser")
 
     def unplug(self, vif):
-        if vif.ovs_hybrid_plug:
+        if vif.vhostuser_ovs_plug:
             port_name = os.path.basename(vif.vhostuser_socket)
             linux_net.delete_ovs_vif_port(vif.bridge_name, port_name,
                                           timeout=self.ovs_vsctl_timeout)


### PR DESCRIPTION
We should invoke delete_ovs_vif_port when vhostuser_ovs_plug
instead of ovs_hybrid_plug.

Signed-off-by: Maxime Leroy maxime.leroy@6wind.com
